### PR TITLE
Bugfix ase_handler.py and dvr_operator_cls.py

### DIFF
--- a/pytdscf/ase_handler.py
+++ b/pytdscf/ase_handler.py
@@ -84,6 +84,9 @@ class DVR_Mesh:
         disp_vec: np.ndarray,
         unit: str = "angstrom",
     ):
+        self.displace = {}
+        self.geometry = {}
+
         self.grid_list = [g.get_grids() for g in dvr_prims]
         self.dvr_prims = dvr_prims
         self.ndof = len(dvr_prims)

--- a/pytdscf/dvr_operator_cls.py
+++ b/pytdscf/dvr_operator_cls.py
@@ -781,7 +781,7 @@ def construct_nMR_recursive(
     elif min(site_order.values()) != 0 or max(site_order.values()) != ndof - 1:
         raise TypeError
     dvr_prims_site_order = [dvr_prims[site_order[p]] for p in active_dofs]
-    ngrids = [dvr_prims_site_order[p].ngrid for p in range(ndof)]
+    ngrids = [dvr_prims_site_order[p].ngrid for p in range(len(active_dofs))]
 
     nMR_operators: dict[tuple[int, ...], TensorOperator | float] = dict()
     if func is None and db is not None and df is None:


### PR DESCRIPTION
ase_handler.py : 
Initialize dict. (`self.displace` and `self.geometry`)
Without this bugfix, in `save_geoms()` `self.displace[(idof,)] = {}` and `self.geometry[dof_key] = {}` do not work.

dvr_operator_cls.py : 
Change setting of ngrids in `construct_nMR_recursive`.
Without this bugfix, length of list is not matched.